### PR TITLE
ci: add /droid review on-comment workflow

### DIFF
--- a/.github/workflows/droid-on-comment.yml
+++ b/.github/workflows/droid-on-comment.yml
@@ -1,0 +1,10 @@
+# Used to run droid on a PR when a comment is made with the command "/droid review".
+# Can be triggered by commenting directly on a PR. The droid-on-comment.yml workflow contains the logic to check if the comment is a valid command and if the commenter has the appropriate association, and then runs droid exec to perform the review.
+name: Droid on comment trigger
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  droid:
+    uses: stakefish/shared-github-actions/.github/workflows/droid-on-comment.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the shared `droid-on-comment` reusable workflow (`stakefish/shared-github-actions/.github/workflows/droid-on-comment.yml@main`) so PRs in this repo can be reviewed by commenting `/droid review`, matching unified-staking-api, solana-api, eth2-oracle, eth2-reward, and staking-daily-reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)